### PR TITLE
Add task, inline code and block-code commands

### DIFF
--- a/src/driver/codemirror/quickCommands/DateHints.ts
+++ b/src/driver/codemirror/quickCommands/DateHints.ts
@@ -12,7 +12,7 @@ export function getDateHints(dateFormat: string) {
     {
       text: dayjs().format(`${dateFormat} HH:mm:ss`),
       displayText: '/now',
-      description: 'now',
+      description: 'Now',
       inline: true
     },
     {

--- a/src/driver/codemirror/quickCommands/MermaidHints.ts
+++ b/src/driver/codemirror/quickCommands/MermaidHints.ts
@@ -7,7 +7,7 @@ const MermaidHints: Hint[] = [
             '\n' +
             '```',
         displayText: '/flowchart',
-        description: 'mermaid flowchart',
+        description: 'Mermaid flowchart',
         inline: false
     },
     {
@@ -16,7 +16,7 @@ const MermaidHints: Hint[] = [
             '\n' +
             '```',
         displayText: '/sequenceDiagram',
-        description: 'mermaid sequence diagram',
+        description: 'Mermaid sequence diagram',
         inline: false
     },
     {
@@ -25,7 +25,7 @@ const MermaidHints: Hint[] = [
             '\n' +
             '```',
         displayText: '/gantt',
-        description: 'mermaid gantt diagram',
+        description: 'Mermaid gantt diagram',
         inline: false
     },
     {
@@ -34,7 +34,7 @@ const MermaidHints: Hint[] = [
             '\n' +
             '```',
         displayText: '/classDiagram',
-        description: 'mermaid class diagram',
+        description: 'Mermaid class diagram',
         inline: false
     },
     {
@@ -43,7 +43,7 @@ const MermaidHints: Hint[] = [
             '\n' +
             '```',
         displayText: '/erDiagram',
-        description: 'mermaid entity relationship diagram',
+        description: 'Mermaid entity relationship diagram',
         inline: false
     },
     {
@@ -52,7 +52,7 @@ const MermaidHints: Hint[] = [
             '\n' +
             '```',
         displayText: '/journey',
-        description: 'mermaid journey diagram',
+        description: 'Mermaid journey diagram',
         inline: false
     }
 ]

--- a/src/driver/codemirror/quickCommands/ShortTypeHints.ts
+++ b/src/driver/codemirror/quickCommands/ShortTypeHints.ts
@@ -1,0 +1,26 @@
+import { Hint } from "./quickCommands";
+
+const ShortTypeHints: Hint[] = [
+    {
+        text: '- [ ] ',
+        displayText: '/task',
+        description: 'Checkbox',
+        inline: true
+    },
+    {
+        text: '``',
+        displayText: '/inline',
+        description: 'Inline Code',
+        inline: true
+    },
+    {
+        text: '```\n' +
+            '\n' +
+            '```',
+        displayText: '/code',
+        description: 'Codeblock',
+        inline: false
+    }
+]
+
+export default ShortTypeHints;

--- a/src/driver/codemirror/quickCommands/quickCommands.ts
+++ b/src/driver/codemirror/quickCommands/quickCommands.ts
@@ -5,6 +5,7 @@ import CodeMirror from "codemirror";
 import PlantumlHints from './PlantumlHints'
 import {getDateHints} from "./DateHints";
 import MermaidHints from "./MermaidHints";
+import ShortTypeHints from "./ShortTypeHints";
 
 const TRIGGER_SYMBOL = '/';
 const HINT_ITEM_CLASS = 'quick-commands-hint';
@@ -31,7 +32,8 @@ let customHints: Hint[] = [
 ]
 
 customHints = customHints.concat(PlantumlHints)
-customHints = customHints.concat(MermaidHints);
+customHints = customHints.concat(MermaidHints)
+customHints = customHints.concat(ShortTypeHints);
 
 interface Completion {
     from: Position;

--- a/src/driver/codemirror/quickCommands/quickCommands.ts
+++ b/src/driver/codemirror/quickCommands/quickCommands.ts
@@ -26,7 +26,7 @@ let customHints: Hint[] = [
     {
         text: '|     |     |     |\r\n| --- | --- | --- |\r\n|     |     |     |',
         displayText: '/table',
-        description: 'markdown table',
+        description: 'Markdown table',
         inline: false
     }
 ]


### PR DESCRIPTION
As discussed in #13 I added the three commands `/task`, `/inline` and `/code`.
Furthermore, some descriptions started with lower case letter and I changed them to upper case that all description fit together.

Sadly, I did not find something to put the cursor between the \` \`

Closes #13 